### PR TITLE
update: added skill files

### DIFF
--- a/.cursor/rules/README.md
+++ b/.cursor/rules/README.md
@@ -1,0 +1,5 @@
+# Cursor (optional)
+
+**Cursor** users: start at **[AGENTS.md](../../AGENTS.md)**. All conventions live in **`skills/*/SKILL.md`**.
+
+This folder only points contributors to **AGENTS.md** so editor-specific config does not duplicate the canonical docs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# Contentstack Model Generator – Agent guide
+
+**Universal entry point** for contributors and AI agents. Detailed conventions live in **`skills/*/SKILL.md`**.
+
+## What this repo is
+
+| Field | Detail |
+| --- | --- |
+| **Name:** | [contentstack/contentstack-model-generator](https://github.com/contentstack/contentstack-model-generator) |
+| **Purpose:** | A **.NET global tool** (`contentstack.model.generator`) that connects to the Content Management API (CMA), fetches content types and global fields from a stack, and **emits C# model classes** (and helpers) under a `Models` output folder. |
+| **Out of scope (if any):** | This package is a **CLI code generator**, not a runtime Contentstack SDK for apps. Product install and CLI flags are documented in [README.md](README.md). |
+
+## Tech stack (at a glance)
+
+| Area | Details |
+| --- | --- |
+| **Language** | C# — tool targets **.NET 7** (`net7.0`); test project targets **.NET 9** (`net9.0`). |
+| **Build** | .NET SDK — solution [contentstack.model.generator/contentstack.model.generator.sln](contentstack.model.generator/contentstack.model.generator.sln); main project [contentstack.model.generator/contentstack.model.generator.csproj](contentstack.model.generator/contentstack.model.generator.csproj) (`PackAsTool`, `PackOnBuild`). |
+| **Tests** | xUnit — project [contentstack.model.generator.tests/contentstack.model.generator.tests.csproj](contentstack.model.generator.tests/contentstack.model.generator.tests.csproj); Moq; coverlet.collector. |
+| **Lint / coverage** | Built-in .NET analyzers; coverlet for coverage in tests. No repo-wide `dotnet format` / StyleCop config in-tree at time of writing. |
+| **Tool dependencies** | [contentstack.model.generator.csproj](contentstack.model.generator/contentstack.model.generator.csproj): McMaster.Extensions.CommandLineUtils, Newtonsoft.Json; HTTP via [HTTPRequestHandler.cs](contentstack.model.generator/CMA/HTTPRequestHandler.cs) (`HttpClient`). |
+| **Consumer projects (generated `Models/`)** | Emitted C# references **Contentstack.Core**, **Contentstack.Utils**, **Newtonsoft.Json**, and **Markdig** (e.g. generated `ContentstackStringExtension`). Those NuGet packages must be added to the **application that uses the generated code**, not to the generator tool project. |
+
+## Commands (quick reference)
+
+| Command type | Command |
+| --- | --- |
+| **Restore** | `dotnet restore contentstack.model.generator/contentstack.model.generator.sln` |
+| **Build** | `dotnet build contentstack.model.generator/contentstack.model.generator.sln` |
+| **Test** | `dotnet test contentstack.model.generator/contentstack.model.generator.sln` |
+| **Pack (tool NuGet)** | From [contentstack.model.generator/](contentstack.model.generator/): CI uses `dotnet pack -c Release -o out` ([nuget-publish.yml](.github/workflows/nuget-publish.yml)), producing `.nupkg` under `contentstack.model.generator/out/`. Local builds also use **`PackOnBuild`** and **`PackageOutputPath`** (`./nupkg`), so packages may appear under `contentstack.model.generator/nupkg/` unless you override with `-o`. |
+| **Install globally (users)** | See [README.md](README.md) (`dotnet tool install -g contentstack.model.generator`). |
+
+**CI / automation:** [.github/workflows/](.github/workflows/) — e.g. branch check ([check-branch.yml](.github/workflows/check-branch.yml)), SCA ([sca-scan.yml](.github/workflows/sca-scan.yml)), CodeQL ([codeql-analysis.yml](.github/workflows/codeql-analysis.yml)), NuGet publish on release ([nuget-publish.yml](.github/workflows/nuget-publish.yml)). **No workflow currently runs `dotnet test`** — run tests locally before opening a PR (see [skills/dev-workflow/SKILL.md](skills/dev-workflow/SKILL.md)).
+
+## Where the documentation lives: skills
+
+| Skill | Path | What it covers |
+| --- | --- | --- |
+| **Dev workflow** | [skills/dev-workflow/SKILL.md](skills/dev-workflow/SKILL.md) | Branches, CI, build/test/pack commands, solution paths. |
+| **Testing** | [skills/testing/SKILL.md](skills/testing/SKILL.md) | Test layout, xUnit/Moq/coverlet, test file map, secrets/credentials. |
+| **Code review** | [skills/code-review/SKILL.md](skills/code-review/SKILL.md) | PR checklist, branch policy, security scans. |
+| **C# / .NET** | [skills/csharp-dotnet/SKILL.md](skills/csharp-dotnet/SKILL.md) | TFMs, namespaces, project layout conventions. |
+| **Framework (libraries)** | [skills/framework/SKILL.md](skills/framework/SKILL.md) | McMaster CLI, Newtonsoft.Json, HTTP client, CMA `Config` / base URL—third-party and platform glue. |
+| **Product (CLI + CMA + codegen)** | [skills/contentstack-model-generator/SKILL.md](skills/contentstack-model-generator/SKILL.md) | End-to-end runtime flow, layers, extension points. |
+
+Quick links to each **SKILL.md**: [skills/README.md](skills/README.md).
+
+## Using Cursor (optional)
+
+If you use **Cursor**, [.cursor/rules/README.md](.cursor/rules/README.md) points to **[AGENTS.md](AGENTS.md)** so editor-specific config does not duplicate the canonical docs.

--- a/contentstack.model.generator/Model/OAuth.cs
+++ b/contentstack.model.generator/Model/OAuth.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using contentstack.model.generator.Model;
+
+namespace Contentstack.Model.Generator.Model
+{
+    /// <summary>
+    /// Represents the response from the OAuth app authorization API.
+    /// </summary>
+    public class OAuthAppAuthorizationResponse
+    {
+
+        [JsonProperty("data")]
+        public OAuthAppAuthorizationData[] Data { get; set; }
+    }
+
+    /// <summary>
+    /// Represents OAuth app authorization data.
+    /// </summary>
+    public class OAuthAppAuthorizationData
+    {
+
+        [JsonProperty("authorization_uid")]
+        public string AuthorizationUid { get; set; }
+
+
+        [JsonProperty("user")]
+        public OAuthUser User { get; set; }
+    }
+
+
+    public class OAuthUser
+    {
+
+        [JsonProperty("uid")]
+        public string Uid { get; set; }
+    }
+
+    /// <summary>
+    /// Configuration options for OAuth authentication.
+    /// </summary>
+    public class OAuthOptions
+    {
+        /// <summary>
+        /// The OAuth application ID. Defaults to the Contentstack app ID.
+        /// </summary>
+        public string AppId { get; set; } = "6400aa06db64de001a31c8a9";
+
+        /// <summary>
+        /// The OAuth client ID. Defaults to the Contentstack client ID.
+        /// </summary>
+        public string ClientId { get; set; } = "Ie0FEfTzlfAHL4xM";
+
+        /// <summary>
+        /// The redirect URI for OAuth callbacks. Defaults to localhost:8184.
+        /// </summary>
+        public string RedirectUri { get; set; } = "http://localhost:8184";
+
+        /// <summary>
+        /// The OAuth client secret. If provided, PKCE flow will be skipped.
+        /// If null or empty, PKCE flow will be used for enhanced security.
+        /// </summary>
+        public string ClientSecret { get; set; }
+
+        /// <summary>
+        /// The OAuth response type. Defaults to "code" for authorization code flow.
+        /// </summary>
+        public string ResponseType { get; set; } = "code";
+
+        /// <summary>
+        /// The OAuth scopes to request. Optional array of permission scopes.
+        /// </summary>
+        public string[] Scope { get; set; }
+
+        /// <summary>
+        /// Indicates whether PKCE (Proof Key for Code Exchange) flow should be used.
+        /// This is automatically determined based on whether ClientSecret is provided.
+        /// </summary>
+        public bool UsePkce => string.IsNullOrEmpty(ClientSecret);
+
+        /// <summary>
+        /// Validates the OAuth options configuration.
+        /// </summary>
+        /// <returns>True if the configuration is valid, false otherwise.</returns>
+        public bool IsValid()
+        {
+            return IsValid(out _);
+        }
+
+        /// <summary>
+        /// Validates the OAuth options configuration and provides detailed error information.
+        /// </summary>
+        /// <param name="errorMessage">The validation error message if validation fails.</param>
+        /// <returns>True if the configuration is valid, false otherwise.</returns>
+        public bool IsValid(out string errorMessage)
+        {
+            errorMessage = null;
+
+            if (string.IsNullOrWhiteSpace(AppId))
+            {
+                errorMessage = "AppId is required for OAuth configuration.";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(ClientId))
+            {
+                errorMessage = "ClientId is required for OAuth configuration.";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(RedirectUri))
+            {
+                errorMessage = "RedirectUri is required for OAuth configuration.";
+                return false;
+            }
+
+            if (!Uri.TryCreate(RedirectUri, UriKind.Absolute, out var redirectUri))
+            {
+                errorMessage = "RedirectUri must be a valid absolute URI.";
+                return false;
+            }
+
+            if (redirectUri.Scheme != "http" && redirectUri.Scheme != "https")
+            {
+                errorMessage = "RedirectUri must use http or https scheme.";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(ResponseType))
+            {
+                errorMessage = "ResponseType is required for OAuth configuration.";
+                return false;
+            }
+
+            if (ResponseType != "code")
+            {
+                errorMessage = "ResponseType must be 'code' for authorization code flow.";
+                return false;
+            }
+
+            // For traditional OAuth flow (non-PKCE), client secret is required
+            if (!UsePkce && string.IsNullOrWhiteSpace(ClientSecret))
+            {
+                errorMessage = "ClientSecret is required for traditional OAuth flow. Use PKCE flow (leave ClientSecret empty) for public clients.";
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Validates the OAuth options configuration and throws an exception if invalid.
+        /// </summary>
+        /// <exception cref="OAuthConfigurationException">Thrown when the configuration is invalid.</exception>
+        public void Validate()
+        {
+            if (!IsValid(out var errorMessage))
+            {
+                throw new Exceptions.OAuthConfigurationException(errorMessage);
+            }
+        }
+
+        /// <summary>
+        /// Gets a string representation of the OAuth options for debugging.
+        /// </summary>
+        /// <returns>A string representation of the OAuth options.</returns>
+        public override string ToString()
+        {
+            return $"OAuthOptions: AppId={AppId}, ClientId={ClientId}, RedirectUri={RedirectUri}, " +
+                   $"ResponseType={ResponseType}, UsePkce={UsePkce}, HasScope={Scope?.Length > 0}";
+        }
+    }
+
+    /// <summary>
+    /// Represents the response from OAuth token exchange operations.
+    /// </summary>
+    public class OAuthResponse
+    {
+
+        [JsonProperty("access_token")]
+        public string AccessToken { get; set; }
+
+
+        [JsonProperty("refresh_token")]
+        public string RefreshToken { get; set; }
+
+
+        [JsonProperty("expires_in")]
+        public int ExpiresIn { get; set; }
+
+
+        [JsonProperty("organization_uid")]
+        public string OrganizationUid { get; set; }
+
+
+        [JsonProperty("user_uid")]
+        public string UserUid { get; set; }
+    }
+    /// <summary>
+    /// Represents OAuth tokens stored in memory for cross-SDK access.
+    /// This class enables sharing OAuth tokens between the Management SDK and other SDKs
+    /// </summary>
+    public class OAuthTokens
+    {
+
+        public string AccessToken { get; set; }
+
+        public string RefreshToken { get; set; }
+
+        public DateTime ExpiresAt { get; set; }
+
+        public string OrganizationUid { get; set; }
+
+        public string UserUid { get; set; }
+
+        public string ClientId { get; set; }
+
+        public string AppId { get; set; }
+
+        public bool IsExpired => ExpiresAt == DateTime.MinValue || DateTime.UtcNow >= ExpiresAt;
+
+        public bool NeedsRefresh
+        {
+            get
+            {
+                // If ExpiresAt is not set or is MinValue, consider it expired
+                if (ExpiresAt == DateTime.MinValue)
+                    return true;
+
+                try
+                {
+                    // Check if we need to refresh (5 minutes before expiration)
+                    var refreshTime = ExpiresAt.AddMinutes(-5);
+                    return DateTime.UtcNow >= refreshTime || IsExpired;
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    // If the calculation results in an unrepresentable DateTime, consider it expired
+                    return true;
+                }
+            }
+        }
+
+        public bool IsValid => !string.IsNullOrEmpty(AccessToken) && !IsExpired;
+    }
+
+}

--- a/contentstack.model.generator/Model/OAuth.cs
+++ b/contentstack.model.generator/Model/OAuth.cs
@@ -157,7 +157,7 @@ namespace Contentstack.Model.Generator.Model
         {
             if (!IsValid(out var errorMessage))
             {
-                throw new Exceptions.OAuthConfigurationException(errorMessage);
+                throw new OAuthConfigurationException(errorMessage);
             }
         }
 
@@ -245,4 +245,13 @@ namespace Contentstack.Model.Generator.Model
         public bool IsValid => !string.IsNullOrEmpty(AccessToken) && !IsExpired;
     }
 
+    /// <summary>
+    /// Thrown when OAuth configuration validation fails in <see cref="OAuthOptions.Validate"/>.
+    /// </summary>
+    public class OAuthConfigurationException : Exception
+    {
+        public OAuthConfigurationException(string message) : base(message)
+        {
+        }
+    }
 }

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,12 @@
+# Skills – Contentstack Model Generator
+
+**Entry point:** [AGENTS.md](../AGENTS.md) — commands, stack, CI, and **which skill to open**.
+
+Each folder holds **SKILL.md** (YAML frontmatter: `name`, `description`).
+
+- [dev-workflow/SKILL.md](dev-workflow/SKILL.md)
+- [testing/SKILL.md](testing/SKILL.md)
+- [code-review/SKILL.md](code-review/SKILL.md)
+- [csharp-dotnet/SKILL.md](csharp-dotnet/SKILL.md)
+- [framework/SKILL.md](framework/SKILL.md)
+- [contentstack-model-generator/SKILL.md](contentstack-model-generator/SKILL.md)

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: code-review
+description: PR checklist, branch policy, versioning notes, and security scan context for this repository.
+---
+
+# Code review – Contentstack Model Generator
+
+## When to use
+
+- Opening or reviewing a pull request.
+- Checking release readiness (version, changelog, package metadata).
+- Ensuring changes align with automated security and branch rules.
+
+## Instructions
+
+### Branch policy
+
+- PRs **into `master`** must be **from `staging`** per [.github/workflows/check-branch.yml](../../.github/workflows/check-branch.yml). Verify head/base before approving merges to `master`.
+- If the PR does not target `master`, the same rule may not apply; still follow team conventions for default branch.
+
+### Review checklist
+
+- **Build and tests:** `dotnet build` and `dotnet test` on `contentstack.model.generator/contentstack.model.generator.sln` succeed (CI does not run `dotnet test`; see [dev-workflow/SKILL.md](../dev-workflow/SKILL.md)).
+- **Release versioning:** For releases, keep `[VersionOption]` in [ModelGenerator.cs](../../contentstack.model.generator/ModelGenerator.cs) (CLI `--version`), **`PackageVersion` / `ReleaseVersion`** in [contentstack.model.generator.csproj](../../contentstack.model.generator/contentstack.model.generator.csproj), and **[CHANGELOG.md](../../CHANGELOG.md)** aligned.
+- **Auth paths:** Traditional `authtoken` vs `--oauth` remain mutually consistent; no accidental logging of secrets.
+- **Codegen output:** Changes to `ModelGenerator` or templates do not break emitted class shapes without **[CHANGELOG.md](../../CHANGELOG.md)** and version bump in **[contentstack.model.generator.csproj](../../contentstack.model.generator/contentstack.model.generator.csproj)** when releasing.
+- **Dependencies:** New package references are justified; Snyk/SCA will scan on PRs ([sca-scan.yml](../../.github/workflows/sca-scan.yml)).
+- **Security-sensitive code:** HTTP, OAuth, and error handling reviewed for information disclosure and robust failure modes.
+
+### Automated security analysis
+
+- **Snyk (SCA):** [.github/workflows/sca-scan.yml](../../.github/workflows/sca-scan.yml) — dependency vulnerabilities.
+- **CodeQL:** [.github/workflows/codeql-analysis.yml](../../.github/workflows/codeql-analysis.yml) — static analysis for C#.
+
+Treat new findings from these workflows as blockers until triaged or waived with documented rationale.
+
+### Product and licensing
+
+- **License** and **copyright** in packaged output follow `contentstack.model.generator.csproj` and [LICENSE](../../LICENSE) / packaged `LICENSE.txt` as applicable.
+- **Security:** Report vulnerabilities per [SECURITY.md](../../SECURITY.md) (not via public GitHub issues).

--- a/skills/contentstack-model-generator/SKILL.md
+++ b/skills/contentstack-model-generator/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: contentstack-model-generator
+description: CLI entry, CMA and OAuth flow, HTTP layer, and C# code generation pipeline for the Contentstack Model Generator tool.
+---
+
+# Contentstack Model Generator – product and runtime flow
+
+## When to use
+
+- Changing **CLI flags**, validation, or exit codes.
+- Modifying **authentication** (authtoken vs OAuth / PKCE) or **CMA** calls.
+- Adjusting **HTTP** behavior or headers.
+- Changing **generated C#** (models, helpers, converters, modular blocks, groups).
+
+## Runtime flow (high level)
+
+Entry: [Program.cs](../../contentstack.model.generator/Program.cs) calls `CommandLineApplication.ExecuteAsync<ModelGenerator>`. Uncaught exceptions print `Messages.UnexpectedError` and return exit code `EXCEPTION` (`2`).
+
+Orchestration: [ModelGenerator.cs](../../contentstack.model.generator/ModelGenerator.cs) — `[Command]` class `ModelGenerator`, method **`OnExecute`**.
+
+### Phases in `ModelGenerator.OnExecute` (order matters)
+
+1. **Validate auth** — If `--oauth`: require client id and redirect URI (and optional secret). Else: require `--authtoken` (`-A`).
+2. **Build `ContentstackOptions`** — API key, host, branch, OAuth fields, optional scopes list.
+3. **OAuth only** — `HandleOAuthFlow`: PKCE verifier → authorization URL → user pastes authorization code → `OAuthService.ExchangeCodeForTokenAsync` → set `Authorization` Bearer (and tokens) on `options`.
+4. **`ContentstackClient`** — Construct with `ContentstackOptions`; constructor sets headers (`api_key`, `authtoken` **or** `Authorization`, optional `branch`) and `Config` from host/version.
+5. **`GetStack()`** — Validates connectivity and loads stack metadata (`StackResponse`).
+6. **Output path** — Resolve `-p` / cwd; append **`/Models`**; create directory if needed.
+7. **Paginated fetch** — `getContentTypes` and `getGlobalFields` with `skip` in steps of **100** until all rows fetched; both append into **`_contentTypes`**.
+8. **Shared generated files** — `CreateEmbeddedObjectClass`, `CreateLinkClass`, `CreateHelperClass`, `CreateStringHelperClass`, `CreateDisplayAttributeClass` (helpers/converters used by emitted types).
+9. **Per content type** — `CreateFile` for each `Contenttype` in `_contentTypes` (handles modular blocks, groups, RTE references via nested `Create*` methods).
+10. **Finish** — Success messages; `OpenFolderatPath` opens the `Models` folder in the OS shell.
+11. **OAuth cleanup** — `OAuthService.LogoutAsync` (failures logged as warnings, non-fatal).
+
+Exit codes: `Program.OK` (`0`), `Program.ERROR` (`1`) on user/API/OAuth failures; `Program.EXCEPTION` (`2`) only from `Program.Main` on unexpected exceptions.
+
+## Layer map
+
+| Layer | Responsibility | Main paths |
+| --- | --- | --- |
+| **CLI bootstrap** | Parse args, top-level exception handling | [Program.cs](../../contentstack.model.generator/Program.cs) |
+| **Command + codegen** | Options, auth, fetch, emit C# text | [ModelGenerator.cs](../../contentstack.model.generator/ModelGenerator.cs) |
+| **CMA client** | Stack, content types, global fields URLs; header assembly; JSON deserialize | [ContentstackClient.cs](../../contentstack.model.generator/CMA/ContentstackClient.cs) |
+| **HTTP** | GET requests, query string, `Authorization` vs custom headers | [HTTPRequestHandler.cs](../../contentstack.model.generator/CMA/HTTPRequestHandler.cs) |
+| **OAuth** | PKCE, authorize URL, token exchange, logout | [OAuthService.cs](../../contentstack.model.generator/CMA/OAuth/OAuthService.cs), [ContentstackOptions.cs](../../contentstack.model.generator/CMA/ContentstackOptions.cs) |
+| **DTOs** | Content types, fields, stack/API JSON shapes; OAuth token/app JSON | [Model/](../../contentstack.model.generator/Model/) — including [OAuth.cs](../../contentstack.model.generator/Model/OAuth.cs) (`Contentstack.Model.Generator.Model`) |
+
+### Debugging API errors
+
+`ContentstackClient.GetContentstackException` is written around **`WebException`**. [HTTPRequestHandler](../../contentstack.model.generator/CMA/HTTPRequestHandler.cs) uses **`HttpClient`** and may throw **`HttpRequestException`**. Parsed CMA error JSON from `GetContentstackException` may not apply on every failure path — check the **actual exception type** when debugging HTTP failures.
+
+## Extension points
+
+| Goal | Where to change |
+| --- | --- |
+| New CLI flag | `[Option]` properties on `ModelGenerator`; consume in `OnExecute`; document in [README.md](../../README.md). |
+| User-facing CLI strings | [Messages.cs](../../contentstack.model.generator/Messages.cs) |
+| New header or API call | `ContentstackClient` methods and/or `HTTPRequestHandler.ProcessRequest`; keep header rules consistent with OAuth vs authtoken. |
+| Field type → C# mapping | `GetDatatype`, `GetDatatypeForField`, `GetDatatypeForContentType` in `ModelGenerator`. |
+| New global emitted type | Add a `Create*` method and invoke it in the same phase as related helpers (order matters for dependencies). |
+| Modular blocks / groups | `CreateModularBlocks`, `CreateGroup`, `CreateModularBlockConverter`, `CreateModularBlockEnum`, etc. |
+
+### File overwrite behavior
+
+`shouldCreateFile` prompts when a file exists unless `--force` (`-f`) is set; returns `null` to skip writing.
+
+User-facing OAuth and install/flags: [OAuth.md](../../OAuth.md), [README.md](../../README.md) (consumer apps need NuGets for generated code: **Contentstack.Core**, **Contentstack.Utils**, **Newtonsoft.Json**, **Markdig** where markdown helpers are used).
+
+If this document grows unwieldy, consider splitting **only** the emit pipeline (modular blocks, groups, `GetDatatype*`) into a separate `code-generation-pipeline` skill and link it from here.

--- a/skills/csharp-dotnet/SKILL.md
+++ b/skills/csharp-dotnet/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: csharp-dotnet
+description: .NET TFMs, namespaces, and source layout conventions for Contentstack Model Generator.
+---
+
+# C# / .NET – Contentstack Model Generator
+
+## When to use
+
+- Adding new `.cs` files or projects.
+- Resolving confusion between tool and test target frameworks.
+- Matching existing namespace and folder patterns.
+
+## Instructions
+
+### Target frameworks
+
+| Project | TFM | Notes |
+| --- | --- | --- |
+| `contentstack.model.generator` | `net7.0` | Global tool executable; `PackAsTool` in csproj. |
+| `contentstack.model.generator.tests` | `net9.0` | `ImplicitUsings` and `Nullable` enabled in test csproj only. |
+
+When adding code to the **tool**, assume **.NET 7** language/API surface unless you raise the TFM in the csproj.
+
+### Namespaces and folders
+
+- **CLI entry and codegen:** `contentstack.model.generator` — e.g. [Program.cs](../../contentstack.model.generator/Program.cs), [ModelGenerator.cs](../../contentstack.model.generator/ModelGenerator.cs). Root namespace in csproj is `Contentstack.Model.Generator`; some types use `contentstack.model.generator` / `contentstack.CMA` style — **follow the file you are editing**.
+- **CMA / HTTP / OAuth:** [contentstack.model.generator/CMA/](../../contentstack.model.generator/CMA/) — `ContentstackClient`, `HTTPRequestHandler`, `ContentstackOptions`, `OAuth/OAuthService`.
+- **JSON DTOs / models:** [contentstack.model.generator/Model/](../../contentstack.model.generator/Model/) — e.g. `Contenttype`, `Field`, stack responses.
+
+### Conventions for new code
+
+- Prefer **async** patterns consistent with existing CMA methods (`async Task`, `await`).
+- Use **Newtonsoft.Json** attributes and patterns already used in generated and hand-written models unless migrating the whole project.
+- Avoid **public API** expansion on the tool’s CLI without updating [README.md](../../README.md) and the `[VersionOption]` / package version in csproj when releasing.

--- a/skills/dev-workflow/SKILL.md
+++ b/skills/dev-workflow/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: dev-workflow
+description: Branches, CI, and dotnet restore/build/test/pack for the Contentstack Model Generator solution.
+---
+
+# Dev workflow – Contentstack Model Generator
+
+## When to use
+
+- Setting up a local build or verifying changes before a PR.
+- Understanding which GitHub Actions run on PRs or releases.
+- Packing or publishing the global tool NuGet package.
+- Anything about **how the CLI and codegen behave** at runtime — see [contentstack-model-generator/SKILL.md](../contentstack-model-generator/SKILL.md).
+
+## Instructions
+
+### Repository layout
+
+- **Solution:** `contentstack.model.generator/contentstack.model.generator.sln`
+- **Tool (executable + pack):** `contentstack.model.generator/contentstack.model.generator.csproj` (`PackAsTool`, `net7.0`).
+- **Tests:** `contentstack.model.generator.tests/contentstack.model.generator.tests.csproj` (`net9.0`).
+
+### Commands (from repository root)
+
+| Step | Command |
+| --- | --- |
+| Restore | `dotnet restore contentstack.model.generator/contentstack.model.generator.sln` |
+| Build | `dotnet build contentstack.model.generator/contentstack.model.generator.sln` |
+| Test | `dotnet test contentstack.model.generator/contentstack.model.generator.sln` |
+| Pack Release | `cd contentstack.model.generator && dotnet pack -c Release -o out` (output `.nupkg` under `contentstack.model.generator/out/`; CI uses similar `dotnet pack` from that directory). |
+
+Package version and metadata: see `PackageVersion` / `ReleaseVersion` in `contentstack.model.generator/contentstack.model.generator.csproj` (avoid duplicating version numbers in prose here).
+
+**CI and unit tests:** No workflow under [.github/workflows/](../../.github/workflows/) runs `dotnet test`. Run `dotnet test contentstack.model.generator/contentstack.model.generator.sln` **locally** before relying on a PR.
+
+**Talisman:** [.talismanrc](../../.talismanrc) may configure secret scanning for this repo. If it references workflow paths that no longer exist (e.g. `.github/workflows/secrets-scan.yml`), update ignores or restore the workflow in a follow-up change.
+
+### Branches and PRs
+
+- Workflow [.github/workflows/check-branch.yml](../../.github/workflows/check-branch.yml): pull requests **into `master`** must come **from `staging`** (other combinations get a failing check and PR comment).
+- Plan feature work accordingly: integrate to `staging` first unless your team documents an exception.
+
+### CI and security workflows (overview)
+
+| Workflow | Role |
+| --- | --- |
+| [check-branch.yml](../../.github/workflows/check-branch.yml) | Enforces `staging` → `master` for PRs targeting `master`. |
+| [sca-scan.yml](../../.github/workflows/sca-scan.yml) | `dotnet restore` + Snyk on .NET assets. |
+| [codeql-analysis.yml](../../.github/workflows/codeql-analysis.yml) | CodeQL for C#. |
+| [nuget-publish.yml](../../.github/workflows/nuget-publish.yml) | On **release created**: pack and push NuGet package(s). |
+| [policy-scan.yml](../../.github/workflows/policy-scan.yml), [issues-jira.yml](../../.github/workflows/issues-jira.yml) | Org/process automation as configured. |
+
+### PR expectations (summary)
+
+- Run **build + test** locally before opening or updating a PR.
+- For user-visible behavior or releases, coordinate **version** and **[CHANGELOG.md](../../CHANGELOG.md)** with maintainers (see [code-review/SKILL.md](../code-review/SKILL.md)).

--- a/skills/framework/SKILL.md
+++ b/skills/framework/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: framework
+description: Third-party and platform libraries used by the tool—CLI, JSON, HTTP, and CMA base URL config—not business logic in ModelGenerator.
+---
+
+# Framework – Contentstack Model Generator
+
+## When to use
+
+- Changing **command-line parsing** (McMaster), **JSON** settings, or **HTTP** behavior.
+- Understanding how **CMA base URL** is built from host/protocol (`Config` / `ContentstackOptions`).
+- Adding or upgrading **NuGet dependencies** on the tool project (with SCA/CodeQL in mind).
+- **Not** for end-to-end product flow — see [contentstack-model-generator/SKILL.md](../contentstack-model-generator/SKILL.md).
+
+## What this repo uses (tool project)
+
+Declared in [contentstack.model.generator.csproj](../../contentstack.model.generator/contentstack.model.generator.csproj):
+
+| Area | Library / API | Where it shows up |
+| --- | --- | --- |
+| **CLI** | **McMaster.Extensions.CommandLineUtils** | [Program.cs](../../contentstack.model.generator/Program.cs) `CommandLineApplication.ExecuteAsync<ModelGenerator>`; `[Command]`, `[Option]`, `[VersionOption]` on [ModelGenerator.cs](../../contentstack.model.generator/ModelGenerator.cs). |
+| **JSON** | **Newtonsoft.Json** | Deserialization in [ContentstackClient.cs](../../contentstack.model.generator/CMA/ContentstackClient.cs) (`JsonConvert`, `JObject`); generated code templates in `ModelGenerator` also emit Newtonsoft attributes. |
+| **HTTP** | **`System.Net.Http.HttpClient`** (via [HTTPRequestHandler.cs](../../contentstack.model.generator/CMA/HTTPRequestHandler.cs)) | GET requests with query string; maps `Authorization` / `api_key` / `authtoken` headers; sets `x-user-agent`. No Polly/retry stack in-repo—retries are not a built-in feature here. |
+| **CMA URL** | [Config.cs](../../contentstack.model.generator/CMA/Config.cs) | Internal `Config` holds protocol, host, port, API version; combined into `BaseUrl` for stack/content_types/global_fields paths used by `ContentstackClient`. |
+
+## Conventions
+
+- **CLI:** Prefer existing McMaster patterns (`[Option]`, `CommandOptionType`, validation attributes) on `ModelGenerator`; keep `--help` and README in sync when adding flags.
+- **JSON:** Respect `JsonSerializerSettings` on `ContentstackClient` when changing deserialize behavior; generated models assume Newtonsoft on the **consumer** side too (see [AGENTS.md](../../AGENTS.md) consumer packages).
+- **HTTP:** Changes to TLS, timeouts, or default `HttpClient` lifetime should stay centralized in `HTTPRequestHandler` (or the type that owns the client) to avoid duplicated policy.
+
+## Packaging
+
+The tool is shipped as a **.NET global tool** (`PackAsTool`). Commands and CI paths: [dev-workflow/SKILL.md](../dev-workflow/SKILL.md).

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: testing
+description: xUnit test layout, how to add new tests, tooling, test file map, and credentials policy for Contentstack Model Generator.
+---
+
+# Testing – Contentstack Model Generator
+
+## When to use
+
+- Adding or fixing unit/integration tests for OAuth, HTTP, CMA client, options, or codegen.
+- Running tests locally with coverage expectations.
+- Deciding how to handle API keys, tokens, or secrets in tests.
+
+## Instructions
+
+### Test project
+
+- **Path:** `contentstack.model.generator.tests/contentstack.model.generator.tests.csproj`
+- **Framework:** `net9.0`
+- **Packages:** xUnit, Moq, `Microsoft.NET.Test.Sdk`, `coverlet.collector`, `Microsoft.AspNetCore.Mvc.Testing` (see csproj for versions).
+- **`Microsoft.AspNetCore.Mvc.Testing`:** Referenced in the test csproj but **not used** by any current `.cs` test file (no `WebApplicationFactory` / similar). Safe candidate for removal in a dedicated change, or keep if you plan integration-style web tests.
+- **Internals:** Main project exposes internals to the test assembly via `InternalsVisibleTo` in `contentstack.model.generator/contentstack.model.generator.csproj`.
+
+### Run tests
+
+From repository root:
+
+```bash
+dotnet test contentstack.model.generator/contentstack.model.generator.sln
+```
+
+With coverage (example using coverlet collector — adjust flags to match your local tooling):
+
+```bash
+dotnet test contentstack.model.generator/contentstack.model.generator.sln --collect:"XPlat Code Coverage"
+```
+
+Run a **single test** or class (examples):
+
+```bash
+dotnet test contentstack.model.generator/contentstack.model.generator.sln --filter "FullyQualifiedName~ContentstackClientTests"
+dotnet test contentstack.model.generator/contentstack.model.generator.sln --filter "FullyQualifiedName~Constructor_ShouldInitializeWithOAuthOptions"
+```
+
+### Adding new tests (step by step)
+
+#### 1. Pick where the test lives
+
+| If you are testing… | Prefer |
+| --- | --- |
+| Existing area in the map below | Add methods to the **existing** `*Tests.cs` file (keeps related cases together). |
+| A new subsystem (new public type, new vertical) | Add a **new** file under `contentstack.model.generator.tests/`, e.g. `MyFeatureTests.cs`, and update the **Test file map** table in this skill in the same PR. |
+| `internal` types in the main project | Rely on **`InternalsVisibleTo`** (`contentstack.model.generator.tests`) — you can reference internals from the test assembly without changing production code for visibility. |
+
+#### 2. Namespace and class shape
+
+- **Namespace:** `contentstack.model.generator.tests` (same as existing tests).
+- **Class name:** suffix **`Tests`**, e.g. `ContentstackClientTests`, `OAuthServiceTests`.
+- **Regions (optional):** In large files, use `#region` blocks (e.g. `#region Property Tests`) like [ModelGeneratorTests.cs](../../contentstack.model.generator.tests/ModelGeneratorTests.cs).
+
+#### 3. Test method naming
+
+Follow patterns already used in this repo:
+
+- **`MethodName_Scenario_ExpectedOutcome`** — e.g. `Constructor_ShouldInitializeWithOAuthOptions`, `GenerateCodeVerifier_ShouldReturnValidBase64UrlEncodedString`.
+- Or **`Feature_ShouldBehavior`** — e.g. `ApiKey_ShouldBeRequired`, `OAuthScopesParsing_ShouldParseCorrectly`.
+
+Names should read clearly in test runners and failure output.
+
+#### 4. xUnit attributes
+
+| Use | When |
+| --- | --- |
+| `[Fact]` | Single scenario, no input matrix. |
+| `[Theory]` + `[InlineData(...)]` | Parameterized cases (multiple inputs → same assertion shape). |
+| `[Theory]` + `[MemberData(nameof(MyData))]` | Larger or shared datasets (use when InlineData becomes unwieldy). |
+
+**Exceptions:** use `Assert.Throws<TException>(() => ...)` (see `Constructor_ShouldHandleNullOptions` in [ContentstackClientTests.cs](../../contentstack.model.generator.tests/ContentstackClientTests.cs)).
+
+**Async:** use `public async Task MethodName_...()` and `await` inside; xUnit supports async test methods.
+
+#### 5. Arrange / Act / Assert
+
+Keep the same structure as existing files:
+
+1. **Arrange** — build `ContentstackOptions`, `ModelGenerator`, mocks, or test data (use obvious **placeholder** strings like `test_api_key`, not real credentials).
+2. **Act** — call the method under test (or construct the object).
+3. **Assert** — `Assert.Equal`, `Assert.NotNull`, `Assert.True`, etc.
+
+Leave a blank line between phases if it helps readability (many tests in this repo separate blocks with spacing).
+
+#### 6. Moq and HTTP
+
+- Use **Moq** when you need substitutes for interfaces or virtual members; follow imports and style in [OAuthServiceTests.cs](../../contentstack.model.generator.tests/OAuthServiceTests.cs) and other OAuth/HTTP tests.
+- For **HTTP**, prefer mocking at the boundary you own (e.g. handlers) rather than hitting real network URLs in unit tests.
+
+#### 7. CLI / `ModelGenerator` options
+
+- For option metadata and validation, tests often use **reflection** (`typeof(ModelGenerator).GetProperty`, `GetCustomAttribute<RequiredAttribute>()`, `OptionAttribute`) — see [ModelGeneratorTests.cs](../../contentstack.model.generator.tests/ModelGeneratorTests.cs).
+- When simulating CLI behavior, you can set properties on `new ModelGenerator()` directly; full end-to-end CLI execution is heavier — keep tests focused and fast unless you add a dedicated integration test.
+
+#### 8. Before you open a PR
+
+- Run the full suite: `dotnet test contentstack.model.generator/contentstack.model.generator.sln`.
+- **CI does not run** `dotnet test` in GitHub Actions today — local green tests are the gate (see [dev-workflow/SKILL.md](../dev-workflow/SKILL.md)).
+- Re-read [Credentials and secrets](#credentials-and-secrets) below — no real tokens or keys in source.
+
+### Test file map
+
+| File | Typical focus |
+| --- | --- |
+| [ContentstackOptionsTests.cs](../../contentstack.model.generator.tests/ContentstackOptionsTests.cs) | `ContentstackOptions` construction and options. |
+| [ContentstackClientTests.cs](../../contentstack.model.generator.tests/ContentstackClientTests.cs) | `ContentstackClient` behavior (headers, config). |
+| [HTTPRequestHandlerTests.cs](../../contentstack.model.generator.tests/HTTPRequestHandlerTests.cs) | HTTP request handling. |
+| [OAuthServiceTests.cs](../../contentstack.model.generator.tests/OAuthServiceTests.cs) | OAuth helpers (PKCE URL generation, etc.). |
+| [OAuthTokenExchangeTests.cs](../../contentstack.model.generator.tests/OAuthTokenExchangeTests.cs) | Token exchange flows. |
+| [OAuthErrorHandlingTests.cs](../../contentstack.model.generator.tests/OAuthErrorHandlingTests.cs) | OAuth error paths. |
+| [OAuthIntegrationTests.cs](../../contentstack.model.generator.tests/OAuthIntegrationTests.cs) | Broader OAuth integration scenarios. |
+| [ModelGeneratorOAuthTests.cs](../../contentstack.model.generator.tests/ModelGeneratorOAuthTests.cs) | CLI / `ModelGenerator` + OAuth interactions. |
+| [ModelGeneratorTests.cs](../../contentstack.model.generator.tests/ModelGeneratorTests.cs) | Codegen / `ModelGenerator` behavior. |
+
+### Credentials and secrets
+
+- **Do not** commit real stack API keys, authtokens, client secrets, or production OAuth codes.
+- Prefer **mocks** (Moq) and **fake/staging** endpoints where integration tests need HTTP; keep secrets in CI **encrypted secrets**, not in source.
+- Vulnerability reporting: [SECURITY.md](../../SECURITY.md) (do not file security issues as public GitHub issues).


### PR DESCRIPTION
## Summary

Adds contributor- and agent-oriented documentation: **`AGENTS.md`**, **`skills/*/SKILL.md`**, a minimal **`skills/README.md`**, and **`.cursor/rules/README.md`**. Documents the tool vs generated-consumer dependency split, pack output locations, and that **CI does not run `dotnet test`**.

## Documentation

- **`AGENTS.md`** — Entry point: purpose, stack, commands, skills table, CI note, Cursor pointer.
- **`skills/README.md`** — Links to each `SKILL.md` only (no duplicated “when to use”; that lives in `AGENTS.md`).
- **Skills** (YAML `name` / `description` frontmatter):
  - `dev-workflow` — branches, workflows, dotnet commands, Talisman note.
  - `testing` — how to add tests, run/filter tests, test file map, secrets.
  - `code-review` — PR checklist, versioning alignment, security reporting.
  - `csharp-dotnet` — TFMs, namespaces, layout.
  - `framework` — McMaster, Newtonsoft, HTTP handler, CMA `Config`.
  - `contentstack-model-generator` — `OnExecute` phases, layer map, extension points, debugging note (no Mermaid).