### PR TITLE
feat: upgrade to .NET 10 and bump version to 1.0.0-beta.1

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -5,13 +5,15 @@ on:
   release:
     types: [created]
 jobs:
-  publish-nuget:  
+  publish-nuget:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
-      - name: Setup .NET Core @ Latest
-        uses: actions/setup-dotnet@v3
+        uses: actions/checkout@v4
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
       - name: Build solution and generate NuGet package
@@ -24,14 +26,15 @@ jobs:
           cd out
           dotnet nuget push "contentstack.model.generator.*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate --no-symbols true --source https://api.nuget.org/v3/index.json
 
-  publish-git:  
+  publish-git:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
-      - name: Setup .NET Core @ Latest
-        uses: actions/setup-dotnet@v3
+        uses: actions/checkout@v4
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
         with:
+          dotnet-version: '10.x'
           source-url: https://nuget.pkg.github.com/Contentstack/index.json
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### Version: 1.0.0-beta.1
-#### Date: Jun-30-2026
+#### Date: 
 
 - Upgraded target framework from net7.0 to net10.0
 - Updated CI/CD pipeline to use .NET 10 SDK (actions/setup-dotnet@v4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### Version: 1.0.0-beta.1
+#### Date: Jun-30-2026
+
+- Upgraded target framework from net7.0 to net10.0
+- Updated CI/CD pipeline to use .NET 10 SDK (actions/setup-dotnet@v4)
+- Updated Microsoft.AspNetCore.Mvc.Testing from 9.0.9 to 10.0.0
+- Fixed GetHeader method visibility (private → internal) to allow test access
+
 ### Version: 0.5.1
 #### Date: Jan-12-2026
 

--- a/contentstack.model.generator.tests/contentstack.model.generator.tests.csproj
+++ b/contentstack.model.generator.tests/contentstack.model.generator.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/contentstack.model.generator/CMA/ContentstackClient.cs
+++ b/contentstack.model.generator/CMA/ContentstackClient.cs
@@ -303,7 +303,7 @@ namespace contentstack.CMA
             }
         }
        
-        private Dictionary<string, object> GetHeader(Dictionary<string, object> localHeader)
+        internal Dictionary<string, object> GetHeader(Dictionary<string, object> localHeader)
         {
             Dictionary<string, object> mainHeader = _StackHeaders;
             Dictionary<string, object> classHeaders = new Dictionary<string, object>();

--- a/contentstack.model.generator/contentstack.model.generator.csproj
+++ b/contentstack.model.generator/contentstack.model.generator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <PackageId>contentstack.model.generator</PackageId>
     <Copyright>Copyright © 2012-2026 Contentstack. All Rights Reserved</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
@@ -13,9 +13,9 @@
     <PackAsTool>true</PackAsTool>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>0.5.1</PackageVersion>
+    <PackageVersion>1.0.0-beta.1</PackageVersion>
     <Authors>Contentstack</Authors>
-    <ReleaseVersion>0.5.1</ReleaseVersion>
+    <ReleaseVersion>1.0.0-beta.1</ReleaseVersion>
     <RootNamespace>Contentstack.Model.Generator</RootNamespace>
      <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReleaseNotes>Improved Error messages</PackageReleaseNotes>


### PR DESCRIPTION
## Summary

- Upgrades the tool runtime from `net7.0` to `net10.0` to align with the Contentstack CDA (`contentstack-dotnet` beta) and CMA (`contentstack-management-dotnet` enhc/beta) SDKs which have both migrated to .NET 10
- Updates CI/CD pipeline to install and use the .NET 10 SDK
- Bumps package version to `1.0.0-beta.1` marking the start of the STJ + .NET 10 migration series

## Changes

| File | Change |
|---|---|
| `contentstack.model.generator.csproj` | `net7.0` → `net10.0`, version `0.5.1` → `1.0.0-beta.1` |
| `contentstack.model.generator.tests.csproj` | `net9.0` → `net10.0`, `Microsoft.AspNetCore.Mvc.Testing` `9.0.9` → `10.0.0` |
| `.github/workflows/nuget-publish.yml` | `checkout@v1` → `@v4`, `setup-dotnet@v3` → `@v4` + `dotnet-version: '10.x'` in both jobs |
| `CMA/ContentstackClient.cs` | `GetHeader` visibility `private` → `internal` (pre-existing test compilation bug) |
| `CHANGELOG.md` | Added `1.0.0-beta.1` release entry |

## Notes

- This PR contains **zero logic changes** — purely framework, tooling, and version updates
- The `GetHeader` fix resolves a pre-existing `CS1061` compilation error in `ContentstackClientTests` that was present before this PR (tests were never running against that file)

## Test Plan

- [x] `dotnet build` — 0 errors on net10.0
- [x] `dotnet test` — 175 passed, 0 failed on net10.0
- [x] `dotnet pack` — valid `1.0.0-beta.1` `.nupkg` produced
- [x] `dotnet tool install --global` + `--help` — CLI runs successfully on net10.0
