### PR TITLE
feat: migrate internal model DTOs from [JsonProperty] to [JsonPropertyName]

### DIFF
--- a/contentstack.model.generator/CMA/ContentStackError.cs
+++ b/contentstack.model.generator/CMA/ContentStackError.cs
@@ -1,8 +1,8 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace contentstack.CMA
 {
@@ -31,7 +31,7 @@ namespace contentstack.CMA
         /// <summary>
         /// This is error message.
         /// </summary>
-        [JsonProperty("error_message")]
+        [JsonPropertyName("error_message")]
         public string ErrorMessage
         {
             get
@@ -48,13 +48,13 @@ namespace contentstack.CMA
         /// <summary>
         /// This is error code.
         /// </summary>
-        [JsonProperty("error_code")]
+        [JsonPropertyName("error_code")]
         public int ErrorCode { get; set; }
 
         /// <summary>
         /// Set of errors in detail.
         /// </summary>
-        [JsonProperty("errors")]
+        [JsonPropertyName("errors")]
         public Dictionary<string, object> Errors { get; set; }
 
         #endregion

--- a/contentstack.model.generator/CMA/OAuth/OAuthService.cs
+++ b/contentstack.model.generator/CMA/OAuth/OAuthService.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace contentstack.CMA.OAuth
 {
@@ -408,25 +409,25 @@ namespace contentstack.CMA.OAuth
 
     public class OAuthTokenResponse
     {
-        [JsonProperty("access_token")]
+        [JsonPropertyName("access_token")]
         public string AccessToken { get; set; }
 
-        [JsonProperty("refresh_token")]
+        [JsonPropertyName("refresh_token")]
         public string RefreshToken { get; set; }
 
-        [JsonProperty("token_type")]
+        [JsonPropertyName("token_type")]
         public string TokenType { get; set; }
 
-        [JsonProperty("expires_in")]
+        [JsonPropertyName("expires_in")]
         public int ExpiresIn { get; set; }
 
-        [JsonProperty("scope")]
+        [JsonPropertyName("scope")]
         public string Scope { get; set; }
 
-        [JsonProperty("organization_uid")]
+        [JsonPropertyName("organization_uid")]
         public string OrganizationUid { get; set; }
 
-        [JsonProperty("user_uid")]
+        [JsonPropertyName("user_uid")]
         public string UserUid { get; set; }
 
         // Computed property for expiration time

--- a/contentstack.model.generator/Model/Contenttype.cs
+++ b/contentstack.model.generator/Model/Contenttype.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace contentstack.model.generator.Model
 {
@@ -11,7 +11,7 @@ namespace contentstack.model.generator.Model
 
         public List<Field> Schema { get; set; }
 
-        [JsonProperty(propertyName: "reference_to")]
+        [JsonPropertyName("reference_to")]
         public string ReferenceTo { get; set; }
     }
 }

--- a/contentstack.model.generator/Model/Field.cs
+++ b/contentstack.model.generator/Model/Field.cs
@@ -1,25 +1,25 @@
 ﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace contentstack.model.generator.Model
 {
     public class Field
     {
-        [JsonProperty(PropertyName = "display_name")]
+        [JsonPropertyName("display_name")]
         public string DisplayName { get; set; }
 
         public string Uid { get; set; }
 
-        [JsonProperty(PropertyName = "data_type")]
+        [JsonPropertyName("data_type")]
         public string DataType { get; set; }
 
-        [JsonProperty(PropertyName = "multiple")]
+        [JsonPropertyName("multiple")]
         public bool IsMultiple { get; set; }
 
-        [JsonProperty(PropertyName = "reference_to")]
+        [JsonPropertyName("reference_to")]
         public object ReferenceTo { get; set; }
 
-        [JsonProperty(PropertyName = "field_metadata")]
+        [JsonPropertyName("field_metadata")]
         public MetaData FieldMetadata { get; set; }
 
         public List<Contenttype> Blocks { get; set; }

--- a/contentstack.model.generator/Model/MetaData.cs
+++ b/contentstack.model.generator/Model/MetaData.cs
@@ -1,28 +1,28 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace contentstack.model.generator.Model
 {
     public class MetaData
     {
-        [JsonProperty(PropertyName = "ref_multiple")]
+        [JsonPropertyName("ref_multiple")]
         public bool RefMultiple { get; set; }
 
-        [JsonProperty(PropertyName = "default_value")]
+        [JsonPropertyName("default_value")]
         public object DefaultValue { get; set; }
 
-        [JsonProperty(PropertyName = "ref_multiple_content_types")]
+        [JsonPropertyName("ref_multiple_content_types")]
         public bool RefMultipleContentType { get; set; }
 
-        [JsonProperty(PropertyName = "allow_rich_text")]
+        [JsonPropertyName("allow_rich_text")]
         public bool IsRichText { get; set; }
 
-        [JsonProperty(PropertyName = "markdown")]
+        [JsonPropertyName("markdown")]
         public bool IsMarkdown { get; set; }
 
-        [JsonProperty(PropertyName = "extension")]
+        [JsonPropertyName("extension")]
         public bool IsExtension { get; set; }
 
-        [JsonProperty(PropertyName = "allow_json_rte")]
+        [JsonPropertyName("allow_json_rte")]
         public bool IsJsonRTE { get; set; }
     }
 }

--- a/contentstack.model.generator/Model/OAuth.cs
+++ b/contentstack.model.generator/Model/OAuth.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using contentstack.model.generator.Model;
 
 namespace Contentstack.Model.Generator.Model
@@ -11,7 +11,7 @@ namespace Contentstack.Model.Generator.Model
     public class OAuthAppAuthorizationResponse
     {
 
-        [JsonProperty("data")]
+        [JsonPropertyName("data")]
         public OAuthAppAuthorizationData[] Data { get; set; }
     }
 
@@ -21,11 +21,11 @@ namespace Contentstack.Model.Generator.Model
     public class OAuthAppAuthorizationData
     {
 
-        [JsonProperty("authorization_uid")]
+        [JsonPropertyName("authorization_uid")]
         public string AuthorizationUid { get; set; }
 
 
-        [JsonProperty("user")]
+        [JsonPropertyName("user")]
         public OAuthUser User { get; set; }
     }
 
@@ -33,7 +33,7 @@ namespace Contentstack.Model.Generator.Model
     public class OAuthUser
     {
 
-        [JsonProperty("uid")]
+        [JsonPropertyName("uid")]
         public string Uid { get; set; }
     }
 
@@ -178,23 +178,23 @@ namespace Contentstack.Model.Generator.Model
     public class OAuthResponse
     {
 
-        [JsonProperty("access_token")]
+        [JsonPropertyName("access_token")]
         public string AccessToken { get; set; }
 
 
-        [JsonProperty("refresh_token")]
+        [JsonPropertyName("refresh_token")]
         public string RefreshToken { get; set; }
 
 
-        [JsonProperty("expires_in")]
+        [JsonPropertyName("expires_in")]
         public int ExpiresIn { get; set; }
 
 
-        [JsonProperty("organization_uid")]
+        [JsonPropertyName("organization_uid")]
         public string OrganizationUid { get; set; }
 
 
-        [JsonProperty("user_uid")]
+        [JsonPropertyName("user_uid")]
         public string UserUid { get; set; }
     }
     /// <summary>

--- a/contentstack.model.generator/Model/StackResponse.cs
+++ b/contentstack.model.generator/Model/StackResponse.cs
@@ -1,14 +1,14 @@
 ﻿using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Contentstack.Model.Generator.Model
 {
     public class StackResponse
     {
-        [JsonProperty(PropertyName = "api_key")]
+        [JsonPropertyName("api_key")]
         public string APIKey { get; set; }
         public string Name { get; set; }
-        [JsonProperty(PropertyName = "master_locale")]
+        [JsonPropertyName("master_locale")]
         public string MasterLocale { get; set; }
         public string Uid { get; set; }
         public string Description { get; set; }


### PR DESCRIPTION
## Summary

- Migrates all internal model DTOs from Newtonsoft.Json `[JsonProperty]` attributes to System.Text.Json `[JsonPropertyName]` attributes
- Removes `using Newtonsoft.Json` imports from all affected model files

## Changes

| File | Change |
|---|---|
| `Model/Field.cs` | `[JsonProperty]` → `[JsonPropertyName]`, `using Newtonsoft.Json` → `using System.Text.Json.Serialization` |
| `Model/MetaData.cs` | Same pattern |
| `Model/Contenttype.cs` | Same pattern |
| `Model/StackResponse.cs` | Same pattern |
| `Model/OAuth.cs` | Same pattern across `OAuthAppAuthorizationResponse`, `OAuthAppAuthorizationData`, `OAuthUser`, `OAuthResponse` |
| `CMA/ContentStackError.cs` | Same pattern across `ErrorMessage`, `ErrorCode`, `Errors` properties |
| `CMA/OAuth/OAuthService.cs` | `[JsonProperty]` → `[JsonPropertyName]` on `OAuthTokenResponse` class properties |

## Notes

- Zero logic changes — purely attribute and import replacements
- All JSON key string values are unchanged, preserving exact API field mappings
- `OAuthService.cs` retains `using Newtonsoft.Json` as `JsonConvert` deserialization calls are addressed in a follow-up PR

## Test Plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 175 passed, 0 failed