### PR TITLE
feat: migrate HTTP layer from Newtonsoft.Json to System.Text.Json

### DIFF
--- a/contentstack.model.generator/CMA/HTTPRequestHandler.cs
+++ b/contentstack.model.generator/CMA/HTTPRequestHandler.cs
@@ -1,5 +1,5 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
+using System.Text.Json;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -14,12 +14,10 @@ namespace contentstack.CMA
     internal class HttpRequestHandler
     {
         private readonly HttpClient _httpClient;
-        private readonly JsonSerializer _serializer;
 
         public HttpRequestHandler()
         {
             _httpClient = new HttpClient();
-            _serializer = new JsonSerializer();
         }
 
         public async Task<string> ProcessRequest(string Url, Dictionary<string, object> Headers, Dictionary<string, object> BodyJson, string FileName = null) 
@@ -37,7 +35,7 @@ namespace contentstack.CMA
                     return value;
                 }
                 else if (kvp.Value is Dictionary<string, object>)
-                    value = JsonConvert.SerializeObject(kvp.Value);
+                    value = JsonSerializer.Serialize(kvp.Value);
                 else
                     return String.Format("{0}={1}", kvp.Key, kvp.Value);
 

--- a/contentstack.model.generator/CMA/Http/ContentstackHttpRequest.cs
+++ b/contentstack.model.generator/CMA/Http/ContentstackHttpRequest.cs
@@ -5,7 +5,7 @@ using System.Net.Http.Headers;
 using System.Collections.Generic;
 using System.Net;
 using System.IO;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace contentstack.CMA.Http
 {
@@ -15,7 +15,7 @@ namespace contentstack.CMA.Http
         private bool _disposed = false;
         private readonly HttpClient _httpClient;
         private readonly HttpRequestMessage _request;
-        private readonly JsonSerializer _serializer;
+        private readonly JsonSerializerOptions _options;
         #endregion
 
         #region Public
@@ -52,10 +52,10 @@ namespace contentstack.CMA.Http
         #endregion
 
         #region Constructor
-        internal ContentstackHttpRequest(HttpClient httpClient, JsonSerializer serializer)
+        internal ContentstackHttpRequest(HttpClient httpClient, JsonSerializerOptions options)
         {
             _httpClient = httpClient;
-            _serializer = serializer;
+            _options = options;
             _request = new HttpRequestMessage();
         }
         #endregion
@@ -124,14 +124,14 @@ namespace contentstack.CMA.Http
 
                 if (responseMessage.StatusCode >= HttpStatusCode.Ambiguous &&
                     responseMessage.StatusCode < HttpStatusCode.BadRequest)
-                    return new ContentstackResponse(responseMessage, _serializer);
+                    return new ContentstackResponse(responseMessage, _options);
 
                 if (!responseMessage.IsSuccessStatusCode)
                 {
                     throw new HttpRequestException($"HTTP request failed with status code: {responseMessage.StatusCode}");
                 }
 
-                return new ContentstackResponse(responseMessage, _serializer);
+                return new ContentstackResponse(responseMessage, _options);
             }
             catch (HttpRequestException httpException)
             {

--- a/contentstack.model.generator/CMA/Http/ContentstackResponse.cs
+++ b/contentstack.model.generator/CMA/Http/ContentstackResponse.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace contentstack.CMA.Http
 {
@@ -20,7 +20,7 @@ namespace contentstack.CMA.Http
         Dictionary<string, string> _headers;
         HashSet<string> _headerNamesSet;
         private readonly HttpResponseMessage _response;
-        private readonly JsonSerializer _serializer;
+        private readonly JsonSerializerOptions _options;
 
         #region Public
         /// <summary>
@@ -126,10 +126,10 @@ namespace contentstack.CMA.Http
         }
         #endregion
 
-        internal ContentstackResponse(HttpResponseMessage response, JsonSerializer serializer)
+        internal ContentstackResponse(HttpResponseMessage response, JsonSerializerOptions options)
         {
             _response = response;
-            _serializer = serializer;
+            _options = options;
 
             this.StatusCode = response.StatusCode;
             this.IsSuccessStatusCode = response.IsSuccessStatusCode;
@@ -146,11 +146,11 @@ namespace contentstack.CMA.Http
         /// <summary>
         /// Json Object format response.
         /// </summary>
-        /// <returns>The JObject.</returns>
-        public JObject OpenJObjectResponse()
+        /// <returns>The JsonObject.</returns>
+        public JsonObject OpenJsonObjectResponse()
         {
             ThrowIfDisposed();
-            return JObject.Parse(OpenResponse());
+            return JsonNode.Parse(OpenResponse())!.AsObject();
         }
 
         /// <summary>
@@ -171,8 +171,8 @@ namespace contentstack.CMA.Http
         public TResponse OpenTResponse<TResponse>()
         {
             ThrowIfDisposed();
-            JObject jObject = OpenJObjectResponse();
-            return jObject.ToObject<TResponse>(_serializer);
+            JsonObject jObject = OpenJsonObjectResponse();
+            return JsonSerializer.Deserialize<TResponse>(jObject.ToJsonString(), _options)!;
         }
 
 

--- a/contentstack.model.generator/CMA/Http/IResponse.cs
+++ b/contentstack.model.generator/CMA/Http/IResponse.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Net;
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 
 namespace contentstack.CMA.Http
 {
@@ -19,7 +19,7 @@ namespace contentstack.CMA.Http
 
         string OpenResponse();
 
-        JObject OpenJObjectResponse();
+        JsonObject OpenJsonObjectResponse();
 
         TResponse OpenTResponse<TResponse>();
     }


### PR DESCRIPTION
## Summary
- Replace all `Newtonsoft.Json` usage in the HTTP abstraction layer with `System.Text.Json`
- Rename `OpenJObjectResponse()` → `OpenJsonObjectResponse()` returning `System.Text.Json.Nodes.JsonObject`
- Swap `Newtonsoft.Json.JsonSerializer` with `System.Text.Json.JsonSerializerOptions` across the request/response pipeline
- Replace `JsonConvert.SerializeObject()` with `JsonSerializer.Serialize()` for query parameter building